### PR TITLE
Add import of path

### DIFF
--- a/restifyOpenapiGenerator.js
+++ b/restifyOpenapiGenerator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 const structuredCloneWrapper = typeof structuredClone === 'function' ? structuredClone : obj => JSON.parse(JSON.stringify(obj));
 


### PR DESCRIPTION
Without this change, the generator doesn't currently work at all in my environment.

```
ERR! App Unhandled rejection: ReferenceError: path is not defined
ERR! App     at RestifyApiGenerate.generateAPiDocs (/Users/louis/Documents/Projects/wildduck/node_modules/restifyapigenerate/restifyOpenapiGenerator.js:232:58)
ERR! App     at RestifyApiGenerate.restifyApiGenerate (/Users/louis/Documents/Projects/wildduck/node_modules/restifyapigenerate/restifyOpenapiGenerator.js:413:14)
ERR! App     at module.exports (/Users/louis/Documents/Projects/wildduck/api.js:589:39)
ERR! App     at /Users/louis/Documents/Projects/wildduck/worker.js:72:29
ERR! App     at Immediate.<anonymous> (/Users/louis/Documents/Projects/wildduck/lmtp.js:200:35)
ERR! App     at process.processImmediate (node:internal/timers:483:21)
```